### PR TITLE
Align devcontainer configuration with readme

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,12 +1,14 @@
 {
 	"name": "Foundry + Node",
-	"image": "mcr.microsoft.com/devcontainers/base:0",
+	"image": "mcr.microsoft.com/devcontainers/base:1",
 	"features": {
-		"ghcr.io/nlordell/features/foundry": {},
+		"ghcr.io/nlordell/features/foundry": {
+			"version": "nightly-cb9dfae298fe0b5a5cdef2536955f50b8c7f0bf5"
+		},
 		"ghcr.io/devcontainers/features/node:1": {}
 	},
 	"customizations": {
-		"vscode" : {
+		"vscode": {
 			"extensions": [
 				"JuanBlanco.solidity"
 			]


### PR DESCRIPTION
The readme specifies the Foundry version to use for the deployment.

This PR hardcodes the Foundry version in the devcontainer to that in the readme as specified in the [feature usage](https://github.com/nlordell/features/tree/main/src/foundry#usage).

I also update the base image from `0` to `1` to make the container work with more up-to-date Foundry versions. Otherwise, `forge` failes to run because there are no compatible GLIBC versions available.

### How to test

- Verify that the commit hash matches the readme
- Verify that the devcontainer can be installed
- Run `forge --version` in the new devcontainer. Expected output:
  ```
  forge 0.2.0 (cb9dfae 2024-07-17T00:19:36.865417953Z)
  ```  